### PR TITLE
breaking change: allow prereqs for instance termination/redeployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,7 +160,7 @@ resource "azurerm_virtual_machine" "instance" {
 resource "null_resource" "instance-prereq" {
   # Changes to any instance of the cluster requires re-provisioning
   triggers {
-    current_ec2_instance_id = "${element(azurerm_virtual_machine.instance.*.id, count.index)}"
+    current_instance_id = "${element(azurerm_virtual_machine.instance.*.id, count.index)}"
   }
 
   # If the user supplies an AMI or custom_data we expect the prerequisites are met.

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,11 @@ resource "azurerm_virtual_machine" "instance" {
 }
 
 resource "null_resource" "instance-prereq" {
+  # Changes to any instance of the cluster requires re-provisioning
+  triggers {
+    current_ec2_instance_id = "${element(azurerm_virtual_machine.instance.*.id, count.index)}"
+  }
+
   # If the user supplies an AMI or custom_data we expect the prerequisites are met.
   count = "${var.num}"
   count = "${(length(var.image) == 0 && var.custom_data == "") ? var.num : 0}"


### PR DESCRIPTION
When instances are terminated from an external source, this change allows the prereqs to be rerun