### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ module "dcos-master-instances" {
 | name_prefix | Cluster Name | string | - | yes |
 | network_security_group_id | Security Group Id | string | `` | no |
 | num | How many instances should be created | string | - | yes |
-| private_backend_address_pool | Private backend address pool | list | `<list>` | no |
-| public_backend_address_pool | Public backend address pool | list | `<list>` | no |
 | resource_group_name | Name of the azure resource group | string | - | yes |
 | ssh_private_key_filename | Path to the SSH private key | string | `/dev/null` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | `` | no |
@@ -51,6 +49,8 @@ module "dcos-master-instances" {
 | Name | Description |
 |------|-------------|
 | admin_username | SSH User |
+| instance_nic_ids | Instance NIC IDs |
+| ip_configuration_names | IP configurations name |
 | prereq_id | Returns the ID of the prereq script |
 | private_ips | Private IP Addresses |
 | public_ips | Public IP Addresses |

--- a/main.tf
+++ b/main.tf
@@ -61,12 +61,12 @@ resource "azurerm_managed_disk" "instance_managed_disk" {
 
 # Public IP addresses for the Public Front End load Balancer
 resource "azurerm_public_ip" "instance_public_ip" {
-  count                        = "${var.num}"
-  name                         = "${format(var.hostname_format, count.index + 1, var.name_prefix)}-pub-ip"
-  location                     = "${var.location}"
-  resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "dynamic"
-  domain_name_label            = "${format(var.hostname_format, count.index + 1, var.name_prefix)}"
+  count               = "${var.num}"
+  name                = "${format(var.hostname_format, count.index + 1, var.name_prefix)}-pub-ip"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+  allocation_method   = "Dynamic"
+  domain_name_label   = "${format(var.hostname_format, count.index + 1, var.name_prefix)}"
 
   tags = "${merge(var.tags, map("Name", format(var.hostname_format, (count.index + 1), var.location, var.name_prefix),
                                 "Cluster", var.name_prefix))}"
@@ -91,11 +91,10 @@ resource "azurerm_network_interface" "instance_nic" {
   count                     = "${var.num}"
 
   ip_configuration {
-    name                                    = "${format(var.hostname_format, count.index + 1, var.name_prefix)}-ipConfig"
-    subnet_id                               = "${var.subnet_id}"
-    private_ip_address_allocation           = "dynamic"
-    public_ip_address_id                    = "${element(azurerm_public_ip.instance_public_ip.*.id, count.index)}"
-    load_balancer_backend_address_pools_ids = ["${compact(concat(var.public_backend_address_pool, var.private_backend_address_pool))}"]
+    name                          = "${format(var.hostname_format, count.index + 1, var.name_prefix)}-ipConfig"
+    subnet_id                     = "${var.subnet_id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${element(azurerm_public_ip.instance_public_ip.*.id, count.index)}"
   }
 
   tags = "${merge(var.tags, map("Name", format(var.hostname_format, (count.index + 1), var.location, var.name_prefix),

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,6 +22,12 @@ output "instance_nic_ids" {
   value       = "${azurerm_network_interface.instance_nic.*.id}"
 }
 
+# IP configurations name
+output "ip_configuration_names" {
+  description = "List of instance nic ids created by this module"
+  value       = ["${data.template_file.ip_configuration_name.*.rendered}"]
+}
+
 # Returns the ID of the prereq script
 output "prereq_id" {
   description = "Prereq id used for dependency"

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,6 +16,12 @@ output "public_ips" {
   value       = ["${azurerm_public_ip.instance_public_ip.*.fqdn}"]
 }
 
+# Instance NIC IDs
+output "instance_nic_ids" {
+  description = "List of instance nic ids created by this module"
+  value       = "${azurerm_network_interface.instance_nic.*.id}"
+}
+
 # Returns the ID of the prereq script
 output "prereq_id" {
   description = "Prereq id used for dependency"

--- a/variables.tf
+++ b/variables.tf
@@ -90,20 +90,6 @@ variable "hostname_format" {
   default     = "instance-%[1]d-%[2]s"
 }
 
-# Public backend address pool
-variable "public_backend_address_pool" {
-  description = "Public backend address pool"
-  type        = "string"
-  default     = ""
-}
-
-# Private backend address pool
-variable "private_backend_address_pool" {
-  description = "Private backend address pool"
-  type        = "string"
-  default     = ""
-}
-
 # Security Group Id
 variable "network_security_group_id" {
   description = "Security Group Id"

--- a/variables.tf
+++ b/variables.tf
@@ -93,15 +93,15 @@ variable "hostname_format" {
 # Public backend address pool
 variable "public_backend_address_pool" {
   description = "Public backend address pool"
-  type        = "list"
-  default     = []
+  type        = "string"
+  default     = ""
 }
 
 # Private backend address pool
 variable "private_backend_address_pool" {
   description = "Private backend address pool"
-  type        = "list"
-  default     = []
+  type        = "string"
+  default     = ""
 }
 
 # Security Group Id


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`